### PR TITLE
Fix IndexError / loss of data for large numbers of lanes

### DIFF
--- a/multiqc_sav/modules/sav/sav.py
+++ b/multiqc_sav/modules/sav/sav.py
@@ -670,8 +670,10 @@ def _parse_imaging_table(data: pd.DataFrame) -> dict:
                 if occ != prev_occ or pf != prev_pf:
                     prev_occ = occ
                     prev_pf = pf
-                    if lane_int is not None and isinstance(lane_int, int) and lane_int < len(colors):
-                        occ_pf[f"Lane {lane_int}"].append({"x": occ, "y": pf, "color": colors[lane_int]})
+                    if lane_int is not None and isinstance(lane_int, int):
+                        # Use modulo to cycle through colors for any number of lanes
+                        color_idx = (lane_int - 1) % len(colors)
+                        occ_pf[f"Lane {lane_int}"].append({"x": occ, "y": pf, "color": colors[color_idx]})
             else:
                 occ_pf = {}
 


### PR DESCRIPTION
The previous code would silently drop data for lanes >= 8 because the Dark2 color palette only has 8 colors (indices 0-7) and lanes are 1-indexed. This fix uses modulo arithmetic to cycle through colors for any number of lanes, preventing data loss.

Fixes #4